### PR TITLE
Check inside a normal repo for existence

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -39,7 +39,7 @@ define git::repo (
 
   $creates = $bare ? {
     true  => "${target}/objects",
-    false => $target,
+    false => "${target}/.git",
   }
 
   exec { "git_repo_for_${name}":


### PR DESCRIPTION
Change target for non-bare repos, so we can create/chown the holding dir before doing the clone.

Without this change, it's not possible to do something like:

file { "/usr/share/foreman":
  ensure => directory,
  owner => 'foreman'
} ->
git-repo { "foreman: user => 'foreman' }

Because '/usr/share' is owned by root. Instead, you have to do the checkout as root and then chown everything afterwards - far messier.
