### PR TITLE
always default to 'git' package

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,15 +18,6 @@
 #
 class git::params (
   $bin = '/usr/bin/git',
-  $package = undef
+  $package = ['git'],
 ) {
-
-  $pkg = $package ? {
-    undef   => $::operatingystem ? {
-      /(?i:Debian|Ubuntu)/ => ['git-core'],
-      default              => ['git'],
-    },
-    default => $package,
-  }
-
 }


### PR DESCRIPTION
debian has deprecated the git-core package, which is now a synonym for the git
package.
Furthermore the conditional had a typo (missing 's' in `$::operatingystem` ), so
git-core has never been used anyways.
