### PR TITLE
Run git from tmp working directory

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -22,7 +22,8 @@ define git::repo (
   $target,
   $bare    = false,
   $source  = false,
-  $user    = 'root'
+  $user    = 'root',
+  $workdir = '/tmp',
 ) {
 
   require git::params
@@ -45,7 +46,8 @@ define git::repo (
   exec { "git_repo_for_${name}":
     command => $cmd,
     creates => $creates,
+    cwd     => $workdir,
     require => Class['git::install'],
-    user    => $user
+    user    => $user,
   }
 }


### PR DESCRIPTION
I have a puppet module that uses this one. It's often applied interactively (puppet apply x.pp) -- but git::repo fails because git clone tries to cd _back_ as $user to the starting point (/root).

```
Jul 11 19:21:03 fedora.katello.example.org puppet-agent[12354]: (/Stage[main]/Stbenjam
::Git/Git::Repo[vundle]/Exec[git_repo_for_vundle]/returns) fatal: Could not change back
to '/root': Permission denied
```
