### PR TITLE
Syncing module configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# This file is managed centrally by modulesync
+#   https://github.com/theforeman/foreman-installer-modulesync
+
 ## MAC OS
 .DS_Store
 
@@ -12,6 +15,23 @@ tmtags
 
 ## VIM
 *.swp
+*.swo
 tags
 
+## Bundler
+Gemfile.lock
+.bundle
+vendor/
+
+## rbenv / rvm
+.rbenv*
+.rvmrc*
+.ruby-*
+
+## rspec
+spec/fixtures/
+
+## Puppet module
 pkg/
+/metadata.json
+coverage/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+---
+# This file is managed centrally by modulesync
+#   https://github.com/theforeman/foreman-installer-modulesync
+rvm:
+  - 1.8.7
+  - 1.9.3
+  - 2.0.0
+env:
+  - PUPPET_VERSION=2.7.0
+  - PUPPET_VERSION=3.2.0
+  - PUPPET_VERSION=3.3
+matrix:
+  allow_failures:
+    # No real support for Ruby 1.9.3 on Puppet 2.x
+    - rvm: 1.9.3
+      env: PUPPET_VERSION=2.7.0
+  exclude:
+    # No support for Ruby 2.0 before Puppet 3.2
+    - rvm: 2.0.0
+      env: PUPPET_VERSION=2.7.0

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,13 @@
+# This file is managed centrally by modulesync
+#   https://github.com/theforeman/foreman-installer-modulesync
+
+source 'https://rubygems.org'
+
+gem 'puppet', ENV.key?('PUPPET_VERSION') ? "~> #{ENV['PUPPET_VERSION']}" : '>= 2.7'
+
+gem 'rake'
+gem 'rspec-puppet', '>= 1'
+gem 'puppetlabs_spec_helper', '>= 0.8.0'
+gem 'simplecov'
+
+# vim:ft=ruby

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,13 @@
+# This file is managed centrally by modulesync
+#   https://github.com/theforeman/foreman-installer-modulesync
+
+require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet-lint/tasks/puppet-lint'
+
+PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp", "vendor/**/*.pp"]
+PuppetLint.configuration.log_format = '%{path}:%{linenumber}:%{KIND}: %{message}'
+PuppetLint.configuration.fail_on_warnings = true
+PuppetLint.configuration.send('disable_80chars')
+PuppetLint.configuration.send('disable_class_inherits_from_params_class')
+
+task :default => [:lint, :validate, :spec]

--- a/spec/spec.opts
+++ b/spec/spec.opts
@@ -1,0 +1,6 @@
+--format
+documentation
+--colour
+--loadby
+mtime
+--backtrace

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,9 @@
+# This file is managed centrally by modulesync
+#   https://github.com/theforeman/foreman-installer-modulesync
+
+require 'puppetlabs_spec_helper/module_spec_helper'
+
+# Workaround for no method in rspec-puppet to pass undef through :params
+class Undef
+  def inspect; 'undef'; end
+end


### PR DESCRIPTION
Part of a cluster of PRs I'm opening which use [modulesync](https://github.com/puppetlabs/modulesync) to synchronise standard config files from https://github.com/theforeman/foreman-installer-modulesync.  Fixes should be made to that central repo.
