### PR TITLE
Add support for bare clones

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -28,14 +28,15 @@ define git::repo (
 
   require git::params
 
+  $args = $bare ? {
+    true    => '--bare',
+    false   => ''
+  }
+
   if $source {
-    $cmd = "${::git::params::bin} clone ${source} ${target} --recursive"
+    $cmd = "${::git::params::bin} clone ${args} --recursive ${source} ${target}"
   } else {
-    if $bare {
-      $cmd = "${::git::params::bin} init --bare ${target}"
-    } else {
-      $cmd = "${::git::params::bin} init ${target}"
-    }
+    $cmd = "${::git::params::bin} init ${args} ${target}"
   }
 
   $creates = $bare ? {


### PR DESCRIPTION
I'm not sure this is the best way to do this but git supports doing bare clones as well. The use case would be doing a bare checkout on an existing repo instead of creating a new one.