### PR TITLE
Move chaining arrows to right operand line

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -62,8 +62,7 @@ define git::repo (
     group  => $group,
     mode   => $mode,
   }
-  ->
-  exec { "git_repo_for_${name}":
+  -> exec { "git_repo_for_${name}":
     command => $cmd,
     creates => $creates,
     cwd     => $workdir,


### PR DESCRIPTION
To match style guide and for compatibility with puppet-lint 2.2.0.