### PR TITLE
Remove redundant symlink

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,5 +1,3 @@
 fixtures:
-  symlinks:
-    git: "#{source_dir}"
   repositories:
     stdlib: 'https://github.com/puppetlabs/puppetlabs-stdlib'


### PR DESCRIPTION
With recent versions of puppetlabs_spec_helper this is done automatically