### PR TITLE
Use the correct type on $source

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -31,7 +31,7 @@
 define git::repo (
   String $target,
   Boolean $bare = false,
-  Boolean $source = false,
+  Optional[String] $source = undef,
   String $user = 'root',
   String $group = 'root',
   String $mode = '0755',


### PR DESCRIPTION
With the type boolean you can't actually clone a source. This corrects the type to a string because source can be both a path and a URL.

Fixes GH-50