### PR TITLE
Support Puppet 7

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -21,7 +21,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 5.5.8 < 7.0.0"
+      "version_requirement": ">= 5.5.8 < 8.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Without this Kafo installers like foreman-installer will choke with an error message, unless --skip-puppet-version-check is enabled.