### PR TITLE
Accept Datatype Sensitive for git source URL

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -37,7 +37,7 @@
 define git::repo (
   String $target,
   Boolean $bare = false,
-  Optional[String] $source = undef,
+  Optional[Variant[String, Sensitive[String]]] $source = undef,
   String $user = 'root',
   String $group = 'root',
   String $mode = '0755',
@@ -52,7 +52,9 @@ define git::repo (
     false   => $args,
   }
 
-  if $source {
+  if $source =~ Sensitive {
+    $cmd = Sensitive.new("${bin} clone ${args_real} --recursive ${source.unwrap} ${target}")
+  } elsif $source {
     $cmd = "${bin} clone ${args_real} --recursive ${source} ${target}"
   } else {
     $cmd = "${bin} init ${args_real} ${target}"


### PR DESCRIPTION
As the Source-String for the Git-Repo may contain sensitive Data, f.e.
an Access-Token, we now accept Datatype Sensitive.
Until the Command "exec" accepts Datatype Sensitive for "$cmd", we have
to unwrap here as a Workaround.