### PR TITLE
Compatibility with puppetlabs/stdlib 9.x

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,5 +18,5 @@ class git (
   Optional[String[1]] $package = undef,
   Optional[String[1]] $package_ensure = undef,
 ) {
-  ensure_packages([$package], { 'ensure' => $package_ensure })
+  stdlib::ensure_packages([$package], { 'ensure' => $package_ensure })
 }

--- a/metadata.json
+++ b/metadata.json
@@ -15,7 +15,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.0 < 9.0.0"
+      "version_requirement": ">= 9.0.0 < 10.0.0"
     }
   ],
   "requirements": [


### PR DESCRIPTION
- fix Warning “This function is deprecated, please use stdlib::ensure_packages instead.”